### PR TITLE
Fix self dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ clean: $(modules.clean)
 
 .PHONY: install
 install:
-	$(PIP) install -r requirements.txt
 	$(PYTHON) setup.py install
+	$(PIP) install -r requirements.txt
 
 
 #-----------------------------------------


### PR DESCRIPTION
`requirements.txt` has listed as its dependency cclyzer. Therefore if install requirements first, pip will fail to find package cclyzer.